### PR TITLE
fix exports config

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,14 +3,13 @@
   "private": true,
   "version": "0.0.1",
   "type": "module",
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
With these changes, I was able to import and use the `spark-ts-sdk` within a React application without the `module not found` error.